### PR TITLE
Update transactions and connections hash

### DIFF
--- a/src/pg-orm/database.cr
+++ b/src/pg-orm/database.cr
@@ -11,8 +11,8 @@ module PgORM::Database
   extend Settings
 
   @@pool : DB::Database?
-  @@connections = {} of LibC::ULong => DB::Connection
-  @@transactions = {} of LibC::ULong => DB::Transaction
+  @@connections = {} of UInt64 => DB::Connection
+  @@transactions = {} of UInt64 => DB::Transaction
   @@info : Info?
 
   def self.configure(&) : Nil


### PR DESCRIPTION
Key type for both hashes was set to LibC::ULong which is set to UInt64 on Linux for 64-bit systems. On Windows, LibC::ULong is set to UInt32. This causes an issue since object_id is UInt64 value for 64-bit systems. This change fixes the issue by making sure that the key type is UInt64 instead of relying on LibC::ULong.